### PR TITLE
Apply same change for BASE_URL for LOG_LEVEL so it can be set as an env variable

### DIFF
--- a/LLM_Export/docker/docker-compose.yaml
+++ b/LLM_Export/docker/docker-compose.yaml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  file-export-server:
+    image: ghcr.io/GlisseManTV/owui-file-export-server:latest
+    container_name: file-export-server
+    environment:
+      - EXPORT_DIR=/data/output
+    ports:
+      - "9003:9003"
+    volumes:
+      - /your/export-data:/data/output
+
+  owui-mcpo:
+    image: ghcr.io/GlisseManTV/owui-mcpo:latest
+    container_name: owui-mcpo
+    environment:
+      - FILE_EXPORT_BASE_URL=http://file-export-server:9003/files
+      - LOG_LEVEL=DEBUG
+      - MCPO_API_KEY=test
+    ports:
+      - "8000:8000"
+    volumes:
+      - /your/export-data:/output
+    depends_on:
+      - file-export-server

--- a/LLM_Export/docker/docker-compose.yaml
+++ b/LLM_Export/docker/docker-compose.yaml
@@ -15,8 +15,10 @@ services:
     container_name: owui-mcpo
     environment:
       - FILE_EXPORT_BASE_URL=http://file-export-server:9003/files
+      - FILE_EXPORT_DIR=/output
+      - MCPO_API_KEY=top-secret
+      - FILES_DELAY=1
       - LOG_LEVEL=DEBUG
-      - MCPO_API_KEY=test
     ports:
       - "8000:8000"
     volumes:

--- a/LLM_Export/docker/docker-compose.yaml
+++ b/LLM_Export/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   file-export-server:
-    image: ghcr.io/GlisseManTV/owui-file-export-server:latest
+    image: ghcr.io/glissemantv/owui-file-export-server:latest
     container_name: file-export-server
     environment:
       - EXPORT_DIR=/data/output
@@ -11,7 +11,7 @@ services:
       - /your/export-data:/data/output
 
   owui-mcpo:
-    image: ghcr.io/GlisseManTV/owui-mcpo:latest
+    image: ghcr.io/glissemantv/owui-mcpo:latest
     container_name: owui-mcpo
     environment:
       - FILE_EXPORT_BASE_URL=http://file-export-server:9003/files

--- a/LLM_Export/docker/mcpo/tools/file_export_mcp.py
+++ b/LLM_Export/docker/mcpo/tools/file_export_mcp.py
@@ -23,6 +23,31 @@ os.makedirs(EXPORT_DIR, exist_ok=True)
 BASE_URL_ENV = os.getenv("FILE_EXPORT_BASE_URL")
 BASE_URL = (BASE_URL_ENV or "http://localhost:9003/files").rstrip("/")
 
+LOG_LEVEL_ENV = os.getenv("LOG_LEVEL")  # e.g., DEBUG, INFO, WARNING, 10, etc.
+LOG_FORMAT_ENV = os.getenv(
+    "LOG_FORMAT", "%(asctime)s %(levelname)s %(name)s - %(message)s"
+)
+
+def _resolve_log_level(val: str | None) -> int:
+    if not val:
+        return logging.INFO
+    v = val.strip()
+    if v.isdigit():
+        try:
+            return int(v)
+        except ValueError:
+            return logging.INFO
+    return getattr(logging, v.upper(), logging.INFO)
+
+# Basic logger (honours LOG_LEVEL if you set it)
+logging.basicConfig(
+    level=_resolve_log_level(LOG_LEVEL_ENV),
+    format=LOG_FORMAT_ENV,
+)
+
+log = logging.getLogger("file_export_mcp")
+log.setLevel(_resolve_log_level(LOG_LEVEL_ENV))
+log.info("Effective LOG_LEVEL -> %s", logging.getLevelName(log.level))
 
 mcp = FastMCP("file_export")
 

--- a/README.md
+++ b/README.md
@@ -123,30 +123,30 @@ Here is an example of a `docker-compose.yaml` file to run both the file export s
 ```yaml
 services:
   file-export-server:
-    image: ghcr.io/glissemantv/owui-file-export-server:dev-latest
+    image: ghcr.io/glissemantv/owui-file-export-server:latest
     container_name: file-export-server
     environment:
-      - FILE_EXPORT_DIR=/data/output
+      - EXPORT_DIR=/data/output
     ports:
-      - 9003:9003
+      - "9003:9003"
     volumes:
-      - /path/to/your/export/folder:/data/output
+      - /your/export-data:/data/output
+
   owui-mcpo:
-    image: ghcr.io/glissemantv/owui-mcpo:dev-latest
+    image: ghcr.io/glissemantv/owui-mcpo:latest
     container_name: owui-mcpo
     environment:
-      - FILE_EXPORT_BASE_URL=http://192.168.0.100:9003/files
+      - FILE_EXPORT_BASE_URL=http://file-export-server:9003/files
       - FILE_EXPORT_DIR=/output
       - MCPO_API_KEY=top-secret
-      - PERSISTENT_FILES=True
       - FILES_DELAY=1
+      - LOG_LEVEL=DEBUG
     ports:
-      - 8000:8000
+      - "8000:8000"
     volumes:
-      - /path/to/your/export/folder:/output
+      - /your/export-data:/output
     depends_on:
       - file-export-server
-networks: {}
 ```
 ---
 


### PR DESCRIPTION
Apply same change for BASE_URL for LOG_LEVEL so it can be set as an env variable, which makes docker/k8s deployment a bit easier.

Also provided a `docker-compose.yaml` example in the docker folder

```yaml
version: "3.9"
services:
  file-export-server:
    image: ghcr.io/GlisseManTV/owui-file-export-server:latest
    container_name: file-export-server
    environment:
      - EXPORT_DIR=/data/output
    ports:
      - "9003:9003"
    volumes:
      - /your/export-data:/data/output

  owui-mcpo:
    image: ghcr.io/GlisseManTV/owui-mcpo:latest
    container_name: owui-mcpo
    environment:
      - FILE_EXPORT_BASE_URL=http://file-export-server:9003/files
      - LOG_LEVEL=DEBUG
      - MCPO_API_KEY=test
    ports:
      - "8000:8000"
    volumes:
      - /your/export-data:/output
    depends_on:
      - file-export-server
```